### PR TITLE
renaming name property back to code

### DIFF
--- a/lib/util/makeErrorFunction.js
+++ b/lib/util/makeErrorFunction.js
@@ -10,7 +10,7 @@ module.exports = function makeErrorFunction(errorCodeName, errorCodeSpec) {
 	return function () {
 		var error = new Error(""), message;
 		error.id = "myId";
-		error.name = errorCodeName;
+		error.code = errorCodeName;
 		//get error message
 		if (errorCodeSpec.args) {
 			var numberOfFormatArguments = (errorCodeSpec.message.match(/\%s|\%d|\%j/g) || []).length;

--- a/test/unit/makeErrorFunction.spec.js
+++ b/test/unit/makeErrorFunction.spec.js
@@ -33,13 +33,13 @@ describe("When making an error function", function () {
 			expect(error.stack).to.be.ok;
 		});
 
-		it("will give it the correct name, id and message", function () {
+		it("will give it the correct code, id and message", function () {
 			var errorCodeSpec = {
 				message:"There was an internal server error"
 			};
 			var fn = makeErrorFunction("system", errorCodeSpec);
 			var errorObject = fn();
-			expect(errorObject.name).to.equal("system");
+			expect(errorObject.code).to.equal("system");
 			expect(errorObject.id).to.be.a("string");
 			expect(errorObject.message).to.equal(errorCodeSpec.message);
 		});

--- a/test/unit/parse.spec.js
+++ b/test/unit/parse.spec.js
@@ -15,7 +15,7 @@ describe("When parsing an error", function () {
 	it("will wrap a normal exception in a system error", function () {
 		var result = parse(new Error("my test"));
 		expect(result).to.have.property("id").to.be.a("string");
-		expect(result.name).to.equal("system");
+		expect(result.code).to.equal("system");
 		expect(result.message).to.equal("There was an internal server error");
 		expect(result.http).to.equal(500);
 		expect(result.internal.innerError).to.be.ok;
@@ -28,7 +28,7 @@ describe("When parsing an error", function () {
 		err.cyclic = getCyclicObject();
 		var result = parse(err);
 		expect(result).to.have.property("id").to.be.a("string");
-		expect(result.name).to.equal("system");
+		expect(result.code).to.equal("system");
 		expect(result.message).to.equal("There was an internal server error");
 		expect(result.http).to.equal(500);
 		expect(result.internal.innerError).to.be.ok;
@@ -48,7 +48,7 @@ describe("When parsing an error", function () {
 		var errorId = err.id;
 		var result = parse(err);
 		expect(result).to.have.property("id").to.be.a("string");
-		expect(result.name).to.equal("test");
+		expect(result.code).to.equal("test");
 		expect(result.message).to.equal("Test");
 		expect(result.http).to.equal(123456);
 		expect(result.cyclic).to.equal("[cyclic or too complex]");


### PR DESCRIPTION
When trying to integrate version 1.2 it became clear that we quite often end up comparing the name to the errorCodes map, and in this case the "name" property is counter-intuitive.

Additionally the update will be easier since we don't have to change the aforementioned comparisons.
